### PR TITLE
Fix cannot find package error

### DIFF
--- a/lib/go-guru-command.js
+++ b/lib/go-guru-command.js
@@ -94,7 +94,7 @@ class GuruCommand {
 
     let userScope = atom.config.get('go-guru.guruUserScope')
     if (userScope) {
-      scope += ', ' + userScope
+      scope += ',' + userScope
     }
 
     console.log(scope)


### PR DESCRIPTION
Plugin searches for scope " <package_name>" instead of "<package_name>" because of space after comma, this little change fixes it.